### PR TITLE
feat: add configuration for alternate broker servers

### DIFF
--- a/snyk-broker/Chart.yaml
+++ b/snyk-broker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/snyk-broker/templates/broker_deployment.yaml
+++ b/snyk-broker/templates/broker_deployment.yaml
@@ -64,6 +64,8 @@ spec:
               {{- end }}              
           {{- end }}
           env:
+            - name: BROKER_SERVER_URL
+              value: {{ .Values.brokerServerUrl }}
           {{- if eq .Values.scmType "github-com" }}
        # Github
             - name: BROKER_TOKEN

--- a/snyk-broker/values.yaml
+++ b/snyk-broker/values.yaml
@@ -7,6 +7,7 @@ replicaCount: 1
 # Snyk Specific Values
 brokerToken: ""
 brokerClientUrl: ""
+brokerServerUrl: "https://broker.snyk.io"
 
 # SCM Generic
 scmType: "github-com"


### PR DESCRIPTION
Adds the BROKER_SERVER_URL environment variable for instances that need to connect to alternate broker servers (for example, in on-premise deployments).

Defaults to https://broker.snyk.io