### PR TITLE
Default gitClientUrl to the address of services templated by chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,10 +159,9 @@ helm install snyk-broker-chart . \
             --set brokerClientUrl=http://<ENTER_SCM_TYPE>-broker-service:8000 \ 
             --set enableCodeAgent=true \ 
             --set snykToken=<ENTER_SNYK_TOKEN> \
-            --set=gitClientUrl=http://code-agent-service:3000 \ 
             -n snyk-broker --create-namespace
 ```
-<b>Note: Leave the ```brokerClientUrl``` and ```gitClientUrl``` values as they are. Also, the accept.json must be in the same directory as the helm chart</b>
+<b>Note: Leave the ```brokerClientUrl``` value as it is. Also, the accept.json must be in the same directory as the helm chart</b>
 
 ## Adding accept.json
 

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -232,7 +232,7 @@ spec:
          # Code Agent
          {{- if .Values.enableCodeAgent }}
             - name: GIT_CLIENT_URL
-              value: {{ .Values.gitClientUrl}} 
+              value: {{ default (printf "http://code-agent-service:%s" (.Values.deployment.container.caSnykPort | toString)) .Values.gitClientUrl }}
          {{- end }}     
          # Logging
             - name: LOG_LEVEL


### PR DESCRIPTION
This just helps reduce some of the configuration values that are necessary to specify. The existing value is still supported if a user needs to override the default setting.