### PR TITLE
Support acceptJson value for passing accept.json contents verbatim as long string via values file

### DIFF
--- a/charts/snyk-broker/templates/_helpers.tpl
+++ b/charts/snyk-broker/templates/_helpers.tpl
@@ -61,3 +61,10 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
+{{/*
+Content of accept.json configuration file (either provided via link to file within chart package or as literal value)
+*/}}
+{{- define "snyk-broker.acceptJson" -}}
+{{- if .Values.acceptJsonFile}}{{.Files.Get .Values.acceptJsonFile}}{{end}}
+{{- with .Values.acceptJson}}{{.}}{{end}}
+{{- end}}

--- a/charts/snyk-broker/templates/accept_configmap.yaml
+++ b/charts/snyk-broker/templates/accept_configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.acceptJsonFile }}
+{{- if (include "snyk-broker.acceptJson" .)}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,5 +8,5 @@ metadata:
     {{- include "snyk-broker.labels" . | nindent 4 }}
 data:
   accept.json: |-
-{{ .Files.Get .Values.acceptJsonFile | indent 4}}
+{{include "snyk-broker.acceptJson" . | indent 4}}
 {{- end }}

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -40,9 +40,8 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.deployment.container.containerPort }}
-          {{- if or .Values.acceptJsonFile .Values.caCert .Values.httpsCert .Values.httpsKey  }}   
           volumeMounts:
-              {{- if .Values.acceptJsonFile }}
+              {{- if (include "snyk-broker.acceptJson" .)}}
               - name: {{ include "snyk-broker.fullname" . }}-accept-volume
                 mountPath: /home/node/private
                 readOnly: true
@@ -62,7 +61,6 @@ spec:
                 mountPath: /home/node/httpskey
                 readOnly: true
               {{- end }}              
-          {{- end }}
           env:
             - name: BROKER_SERVER_URL
               value: {{ .Values.brokerServerUrl }}
@@ -274,7 +272,7 @@ spec:
               value: {{ .Values.httpsProxy }}
          {{- end }}
 
-         {{- if .Values.acceptJsonFile }}
+         {{- if (include "snyk-broker.acceptJson" .)}}
          # Accept.json Environment Variables
             - name: ACCEPT
               value: /home/node/private/accept.json
@@ -283,11 +281,9 @@ spec:
               value: /home/node/accept.json
          {{- end }}
 
-         # Mount Accept.json and Certs       
-
-      {{- if or .Values.acceptJsonFile .Values.caCert .Values.httpsCert .Values.httpsKey  }}   
+      # Mount Accept.json and Certs       
       volumes:
-      {{- if .Values.acceptJsonFile }}
+      {{- if (include "snyk-broker.acceptJson" .)}}
       - name: {{ include "snyk-broker.fullname" . }}-accept-volume
         configMap:
           name: {{ include "snyk-broker.fullname" . }}-accept-configmap
@@ -306,7 +302,4 @@ spec:
       - name: {{ include "snyk-broker.fullname" . }}-httpskey-volume
         configMap:
           name: {{ include "snyk-broker.fullname" . }}-httpskey-configmap
-      {{- end }}
-      
-      {{- end }}
-
+      {{- end }}      

--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -73,6 +73,8 @@ httpsProxy: ""
 
 # Specify a local accept.json file (relative to snyk-broker folder) to inject with a ConfigMap, e.g. "files/accept.json"
 acceptJsonFile: ""
+# Specify the accept.json file contents verbatim
+acceptJson: ""
 
 image:
   repository: snyk/broker


### PR DESCRIPTION
The changes in this PR add support for an additional value called `acceptJson` which is an alternative to the existing `acceptJsonFile`. For users that are installing this chart from the helm repo, they cannot easily load a custom file into the chart package to reference from `acceptJsonFile`. The new value allows a user to embed the contents of their desired `accept.json` contents as a long literal string in a YAML values file. For example, something like the following:
```
$ helm install snyk-broker-gitub-com snyk-broker/snyk-broker -f values.yaml -n snyk-broker --create-namespace
$ cat values.yaml
scmType: github-com
brokerToken: <ENTER_BROKER_TOKEN>
scmToken: <ENTER_REPO_TOKEN>
acceptJson: |-
  {
    "public": [
      {
        "//": "used for pushing up webhooks from github",
        "method": "POST",
        "path": "/webhook/github",
        "valid": [
          {
            "//": "accept all pull request state changes (these don't have files in them)",
            "path": "pull_request.state",
            "value": "open"
          },
          {
            "path": "commits.*.added.*",
            "value": "package.json"
          },
  ...
    ]
  }
```